### PR TITLE
Fix OS X compilation errors

### DIFF
--- a/main.c
+++ b/main.c
@@ -11,7 +11,7 @@
 #include <openssl/rsa.h>
 #include <openssl/pem.h>
 
-#ifdef _WIN32 || _WIN64
+#if defined(_WIN32) || defined(_WIN64)
 #include <Windows.h>
 #define msleep(x) Sleep(x)
 #else
@@ -37,7 +37,7 @@ struct timeval startTime;
 int GetCoreCount()
 {
     int cores = 1;
-    #ifdef _WIN32 || _WIN64
+    #if defined(_WIN32) || defined(_WIN64)
         SYSTEM_INFO sysinfo;
         GetSystemInfo( &sysinfo );
         cores = sysinfo.dwNumberOfProcessors;
@@ -153,7 +153,7 @@ int main(int argc, char ** argv)
             threads.push_back(cThread);
             blobs.push_back(new queue<Blob>());
             pthread_mutex_t * mutex = new pthread_mutex_t();
-            *mutex = PTHREAD_MUTEX_INITIALIZER;
+            *mutex = (pthread_mutex_t) PTHREAD_MUTEX_INITIALIZER;
             mutexes.push_back(mutex);
             pthread_create(cThread, NULL, crackThread, (void*)x);
         }


### PR DESCRIPTION
If you try to build this on OS X, you'll get a few compilation errors:

```console
$ make
g++ -pthread main.c src/Blob.c -o pemcracker -lssl -lcrypto -O3
clang: warning: treating 'c' input as 'c++' when in C++ mode, this behavior is deprecated
clang: warning: treating 'c' input as 'c++' when in C++ mode, this behavior is deprecated
main.c:14:15: warning: extra tokens at end of #ifdef directive [-Wextra-tokens]
#ifdef _WIN32 || _WIN64
              ^
              //
main.c:40:19: warning: extra tokens at end of #ifdef directive [-Wextra-tokens]
    #ifdef _WIN32 || _WIN64
                  ^
                  //
main.c:156:22: error: expected expression
            *mutex = PTHREAD_MUTEX_INITIALIZER;
                     ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/usr/include/pthread.h:179:35: note: 
      expanded from macro 'PTHREAD_MUTEX_INITIALIZER'
#define PTHREAD_MUTEX_INITIALIZER {_PTHREAD_MUTEX_SIG_init, {0}}
                                  ^
2 warnings and 1 error generated.
make: *** [pemcracker] Error 1
```

I've made the necessary changes to fix these errors.